### PR TITLE
Remove CloudKit entitlements to fix sideloaded app crashes

### DIFF
--- a/src/SideloadFix.xm
+++ b/src/SideloadFix.xm
@@ -1,17 +1,17 @@
 #import "Header.h"
 
-%hook CKEntitlements
-- (id)initWithEntitlementsDict:(NSDictionary *)entitlements {
-	NSMutableDictionary *mutableDict = [entitlements mutableCopy];
-	[mutableDict removeObjectForKey:@"com.apple.developer.icloud-container-environment"];
-	[mutableDict removeObjectForKey:@"com.apple.developer.icloud-services"];
-	return %orig([mutableDict copy]);
-}
-%end
-
 %hook CKContainer
 - (id)_setupWithContainerID:(id)a options:(id)b { return nil; }
 - (id)_initWithContainerIdentifier:(id)a { return nil; }
+%end
+
+%hook CKEntitlements
+- (id)initWithEntitlementsDict:(NSDictionary *)entitlements {
+	NSMutableDictionary *mutEntitlements = [entitlements mutableCopy];
+	[mutEntitlements removeObjectForKey:@"com.apple.developer.icloud-container-environment"];
+	[mutEntitlements removeObjectForKey:@"com.apple.developer.icloud-services"];
+	return %orig([mutEntitlements copy]);  // why? whatever
+}
 %end
 
 %hook NSFileManager

--- a/src/SideloadFix.xm
+++ b/src/SideloadFix.xm
@@ -1,5 +1,19 @@
 #import "Header.h"
 
+%hook CKEntitlements
+
+- (id)initWithEntitlementsDict:(NSDictionary *)entitlements {
+ 
+ NSMutableDictionary *mutableDict = [entitlements mutableCopy];
+ 
+ [mutableDict removeObjectForKey:@"com.apple.developer.icloud-container-environment"];
+ [mutableDict removeObjectForKey:@"com.apple.developer.icloud-services"];
+ 
+ return %orig([mutableDict copy]);
+} 
+
+%end
+
 %hook CKContainer
 - (id)_setupWithContainerID:(id)a options:(id)b { return nil; }
 - (id)_initWithContainerIdentifier:(id)a { return nil; }

--- a/src/SideloadFix.xm
+++ b/src/SideloadFix.xm
@@ -1,17 +1,12 @@
 #import "Header.h"
 
 %hook CKEntitlements
-
 - (id)initWithEntitlementsDict:(NSDictionary *)entitlements {
- 
- NSMutableDictionary *mutableDict = [entitlements mutableCopy];
- 
- [mutableDict removeObjectForKey:@"com.apple.developer.icloud-container-environment"];
- [mutableDict removeObjectForKey:@"com.apple.developer.icloud-services"];
- 
- return %orig([mutableDict copy]);
-} 
-
+	NSMutableDictionary *mutableDict = [entitlements mutableCopy];
+	[mutableDict removeObjectForKey:@"com.apple.developer.icloud-container-environment"];
+	[mutableDict removeObjectForKey:@"com.apple.developer.icloud-services"];
+	return %orig([mutableDict copy]);
+}
 %end
 
 %hook CKContainer


### PR DESCRIPTION
## Changes
- Added `%hook CKEntitlements`
- Removed `com.apple.developer.icloud-container-environment` entitlement
- Removed `com.apple.developer.icloud-services` entitlement

## Why?
Removing these entitlements prevents validation failures and CloudKit initialization errors,  
This stopped apps from crashing that had been crashing before.

cc: @chocolatefluffy
